### PR TITLE
Fix regex patterns to support hyphens in organization slugs

### DIFF
--- a/source/Background/domains.ts
+++ b/source/Background/domains.ts
@@ -11,10 +11,10 @@ export type DevOrigin =
 export type Origin = ProdOrigin | DevOrigin;
 
 const ORIGIN_PATTERNS = {
-  prod: [/^https:\/\/((?<orgSlug>[\w]*)\.)?(?<domain>sentry\.io)$/],
+  prod: [/^https:\/\/((?<orgSlug>[\w-]*)\.)?(?<domain>sentry\.io)$/],
   dev: [
-    /^https:\/\/((?<orgSlug>[\w]*)\.)?(?<domain>sentry\.dev)$/,
-    /^https:\/\/((?<orgSlug>[\w]*)\.)?(?<domain>dev\.getsentry\.net:7999)$/,
+    /^https:\/\/((?<orgSlug>[\w-]*)\.)?(?<domain>sentry\.dev)$/,
+    /^https:\/\/((?<orgSlug>[\w-]*)\.)?(?<domain>dev\.getsentry\.net:7999)$/,
   ],
 };
 
@@ -33,10 +33,10 @@ export type DevDomain =
 export type Domain = ProdDomain | DevDomain;
 
 const DOMAIN_PATTERNS = {
-  prod: [/^((?<orgSlug>[\w]*)\.)?(?<domain>sentry\.io)$/],
+  prod: [/^((?<orgSlug>[\w-]*)\.)?(?<domain>sentry\.io)$/],
   dev: [
-    /^((?<orgSlug>[\w]*)\.)?(?<domain>sentry\.dev)$/,
-    /^((?<orgSlug>[\w]*)\.)?(?<domain>dev\.getsentry\.net:7999)$/,
+    /^((?<orgSlug>[\w-]*)\.)?(?<domain>sentry\.dev)$/,
+    /^((?<orgSlug>[\w-]*)\.)?(?<domain>dev\.getsentry\.net:7999)$/,
   ],
 };
 


### PR DESCRIPTION
Updated all regex patterns in ORIGIN_PATTERNS and DOMAIN_PATTERNS to include hyphens by changing [w]* to [w-]*, allowing organization slugs to contain letters, digits, underscores, and hyphens.