### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup Node v${{ env.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: ${{ env.node-version }}
           cache: 'yarn'
@@ -26,7 +26,7 @@ jobs:
       - run: yarn install --frozen-lockfile
 
       - name: Fetch next version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@aacd18f07c808c12edb372dc9f9e7160f06c72e8 # v6.1
         id: find_version
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
 
       - run: yarn run build
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         with:
           name: extensions
           path: extension/
@@ -63,20 +63,20 @@ jobs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}
 
     steps:
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           name: extensions
           path: extension/
 
       - name: Bump version and push tag
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@aacd18f07c808c12edb372dc9f9e7160f06c72e8 # v6.1
         id: tag_version
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
 
       - name: Create GitHub release tag ${{ steps.tag_version.outputs.new_tag }}
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
@@ -97,7 +97,7 @@ jobs:
           - firefox
           - sentry
     steps:
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           name: extensions
           path: extension/
@@ -120,7 +120,7 @@ jobs:
 
       - name: Sentry Release
         if: matrix.command == 'sentry' && needs.package.outputs.new_tag
-        uses: getsentry/action-release@v1.3.0
+        uses: getsentry/action-release@85e0095193a153d57c458995f99d0afd81b9e5ea # v1.3.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)