### PR TITLE
chore(node): set node to LTS v22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      node-version: 19.x # See Node.js release schedule: https://nodejs.org/en/about/releases/
+      node-version: 22.x # See Node.js release schedule: https://nodejs.org/en/about/releases/
 
     steps:
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      node-version: 19.x # See Node.js release schedule: https://nodejs.org/en/about/releases/
+      node-version: 22.x # See Node.js release schedule: https://nodejs.org/en/about/releases/
     outputs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}
 
@@ -87,7 +87,7 @@ jobs:
     needs: package
     runs-on: ubuntu-latest
     env:
-      node-version: 19.x # See Node.js release schedule: https://nodejs.org/en/about/releases/
+      node-version: 22.x # See Node.js release schedule: https://nodejs.org/en/about/releases/
 
     strategy:
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=22.0.0",
     "yarn": ">= 1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Should fix [current CI failure](https://github.com/getsentry/cookie-sync/actions/runs/23947889578/job/69848071381) on `main`