### PR TITLE
fix(open): bad regex in url replacement

### DIFF
--- a/source/Popup/Popup.tsx
+++ b/source/Popup/Popup.tsx
@@ -47,7 +47,7 @@ export default function Popup() {
                 }
 
                 const newUrl = tab.url?.replace(
-                  /([^/\s]+\.sentry\.dev|sentry\.io)$/,
+                  /([^/\s]+\.sentry\.dev|sentry\.io)/,
                   'dev.getsentry.net:7999'
                 );
                 return browser.tabs.create({url: newUrl});


### PR DESCRIPTION
When #37 added support for `*.sentry.dev` deploy previews, the regex was updated with an incorrect `$` which broke the "Open in Dev UI" button. 

This PR removes the `$`, fixing the button.